### PR TITLE
bugfix: fixed http parameter name, should be project

### DIFF
--- a/src/main/kotlin/com/liftric/dtcp/service/DependencyTrack.kt
+++ b/src/main/kotlin/com/liftric/dtcp/service/DependencyTrack.kt
@@ -69,7 +69,7 @@ class DependencyTrack(apiKey: String, private val baseUrl: String) {
         val res = client.uploadFileWithFormData(url, file, "bom") {
             append("autoCreate", autoCreate)
             projectUUID?.let {
-                append("projectUUID", it)
+                append("project", it)
             }
             projectName?.let {
                 append("projectName", it)


### PR DESCRIPTION
Small for uploading SBOM, parameter name should be 'project', not 'projectUUID'.