### PR TITLE
fix: serialization error directDependencies

### DIFF
--- a/src/main/kotlin/com/liftric/dtcp/model/DependencyTrack.kt
+++ b/src/main/kotlin/com/liftric/dtcp/model/DependencyTrack.kt
@@ -24,7 +24,7 @@ data class Project(
     val version: String,
     val active: Boolean,
     val classifier: String,
-    val directDependencies: String,
+    val directDependencies: String? = null,
     val lastInheritedRiskScore: Double? = null,
 )
 

--- a/src/main/kotlin/com/liftric/dtcp/tasks/GetOutdatedDependenciesTask.kt
+++ b/src/main/kotlin/com/liftric/dtcp/tasks/GetOutdatedDependenciesTask.kt
@@ -51,6 +51,10 @@ abstract class GetOutdatedDependenciesTask : DefaultTask() {
             else -> throw GradleException("Either projectUUID or projectName and projectVersion must be set")
         }
 
+        if (project.directDependencies == null) {
+            throw GradleException("Project does not have direct dependencies")
+        }
+
         val directDependencies = Json {
             ignoreUnknownKeys = true
         }.decodeFromString<List<DirectDependency>>(project.directDependencies)


### PR DESCRIPTION
The "directDependency" String from the response of project/lookup can be null.
to fix the serialization error, we make this attribute nullable and warn the user in GetOutdatedDependenciesTask if the project has no direct dependencies.

also fix an issue in the riskScore task, when the sbom analyse failed and the project then has no direct dependencies.