### PR TITLE
refactor: Decoupling Project Analysis from Risk Score Check

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,15 @@ This plugin internally applies the [CycloneDX Gradle plugin](https://github.com/
 
 The plugin offers several tasks:
 
-- `runDepTrackWorkflow`: Runs `generateSbom`, `uploadSbom`, `generateVex`, `uploadVex` and `riskScore` tasks for CI/CD.
 - `generateSbom`: Generates the SBOM (Runs "cyclonedxBom" from [cyclonedx-gradle-plugin](https://github.com/CycloneDX/cyclonedx-gradle-plugin) under the hood)
 - `uploadSbom`: Uploads SBOM file.
 - `generateVex`: Generates VEX file.
 - `uploadVex`: Uploads VEX file.
+- `analyzeProject`: Triggers Vulnerability Analysis on a specific project
+- `riskScore`: Gets risk score. If the risk score is higher than the specified value, the task will fail.
 - `getOutdatedDependencies`: Gets outdated dependencies.
 - `getSuppressedVuln`: Gets suppressed vulnerabilities.
-- `riskScore`: Gets risk score. If the risk score is higher than the specified value, the task will fail.
+- `runDepTrackWorkflow`: Runs `generateSbom`, `uploadSbom`, `generateVex` and `uploadVex` tasks for CI/CD.
 
 ### Task Configuration
 
@@ -59,6 +60,14 @@ Each task requires certain inputs which are to be specified in your `build.gradl
 - `riskScore`: *Optional* - Used for failing the task if the risk score is higher than the specified value.
    - `timeout`: *Optional* - If specified, the task will wait for the risk score to be calculated. Default: 0 seconds
    - `maxRiskScore`: *Optional* - If specified, the task will fail if the risk score is higher than the specified value.
+
+#### analyzeProject
+
+- `url`: Dependency Track API URL
+- `apiKey`: Dependency Track API KEY
+- `projectUUID`: *Optional* - You need to set UUID or projectName and projectVersion
+- `projectName`: *Optional* - You need to set UUID or projectName and projectVersion
+- `projectVersion`: *Optional* - You need to set UUID or projectName and projectVersion
 
 #### getOutdatedDependencies
 

--- a/src/main/kotlin/com/liftric/dtcp/DepTrackCompanionPlugin.kt
+++ b/src/main/kotlin/com/liftric/dtcp/DepTrackCompanionPlugin.kt
@@ -87,14 +87,13 @@ class DepTrackCompanionPlugin : Plugin<Project> {
             task.projectName.set(extension.projectName)
             task.projectVersion.set(extension.projectVersion)
             task.riskScore.set(extension.riskScoreData)
-            task.mustRunAfter(uploadVex)
         }
 
         project.tasks.register("runDepTrackWorkflow") { task ->
             task.group = taskGroup
             task.description =
-                "Runs uploadSbom, generateVex and uploadVex for CI/CD"
-            task.dependsOn(generateSbom, uploadSbom, generateVex, uploadVex, riskScore)
+                "Runs generateSbom, uploadSbom, generateVex, uploadVex for CI/CD integration"
+            task.dependsOn(generateSbom, uploadSbom, generateVex, uploadVex)
         }
 
         project.tasks.register("getOutdatedDependencies", GetOutdatedDependenciesTask::class.java) { task ->

--- a/src/main/kotlin/com/liftric/dtcp/DepTrackCompanionPlugin.kt
+++ b/src/main/kotlin/com/liftric/dtcp/DepTrackCompanionPlugin.kt
@@ -68,6 +68,16 @@ class DepTrackCompanionPlugin : Plugin<Project> {
             task.dependsOn(generateVex)
         }
 
+        val analyzeProject = project.tasks.register("analyzeProject", AnalyzeProjectTask::class.java) { task ->
+            task.group = taskGroup
+            task.description = "Triggers Vulnerability Analysis on a specific project\n"
+            task.apiKey.set(extension.apiKey)
+            task.url.set(extension.url)
+            task.projectUUID.set(extension.projectUUID)
+            task.projectName.set(extension.projectName)
+            task.projectVersion.set(extension.projectVersion)
+        }
+
         val riskScore = project.tasks.register("riskScore", RiskScoreTask::class.java) { task ->
             task.group = taskGroup
             task.description = "Get Risk Score"

--- a/src/main/kotlin/com/liftric/dtcp/tasks/AnalyzeProjectTask.kt
+++ b/src/main/kotlin/com/liftric/dtcp/tasks/AnalyzeProjectTask.kt
@@ -1,0 +1,53 @@
+package com.liftric.dtcp.tasks
+
+import com.liftric.dtcp.service.DependencyTrack
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
+
+abstract class AnalyzeProjectTask : DefaultTask() {
+    @get:Input
+    abstract val apiKey: Property<String>
+
+    @get:Input
+    abstract val url: Property<String>
+
+    @get:Input
+    @get:Optional
+    abstract val projectUUID: Property<String>
+
+    @get:Input
+    @get:Optional
+    abstract val projectName: Property<String>
+
+    @get:Input
+    @get:Optional
+    abstract val projectVersion: Property<String>
+
+    @TaskAction
+    fun analyzeProjectTask() {
+        val apiKeyValue = apiKey.get()
+        val urlValue = url.get()
+
+        val projectUUIDValue = projectUUID.orNull
+        val projectNameValue = projectName.orNull
+        val projectVersionValue = projectVersion.orNull
+
+        val dt = DependencyTrack(apiKeyValue, urlValue)
+
+        val uuid = when {
+            projectUUIDValue != null -> projectUUIDValue
+            projectNameValue != null && projectVersionValue != null -> dt.getProject(
+                projectNameValue,
+                projectVersionValue
+            ).uuid
+
+            else -> throw GradleException("Either projectUUID or projectName and projectVersion must be set")
+        }
+
+        dt.analyzeProjectFindings(uuid)
+    }
+}


### PR DESCRIPTION
This pull request introduces a significant structural improvement to the Dependency Track plugin by decoupling the project analysis process from the risk score check. Previously, these two functionalities were bundled together in a single task, leading to inefficiencies and the need for timeouts due to the time Dependency Track takes to analyze projects.

Key changes in this update include:

- Introduction of analyzeProject Task: A new, standalone task that exclusively handles the analysis of projects. This task allows for more precise control over when and how project analysis is triggered, especially useful for projects initially created as inactive.

- Refinement of Risk Score Check: The risk score check functionality has been isolated into its own task, eliminating the need for timeouts and streamlining the process. This change allows for the risk score check to be integrated at a later stage in the pipeline, such as post end-to-end testing, enhancing the overall workflow efficiency.

- Updated runDepTrackWorkflow Task: The runDepTrackWorkflow task no longer includes the risk score check. Users who prefer the comprehensive workflow must now explicitly invoke the riskScore task alongside runDepTrackWorkflow.

This pull request introduces a **breaking change** for users who rely solely on the runDepTrackWorkflow task for risk score assessment. To adapt to this change, such users will need to include the riskScore task in their pipeline explicitly.

The aim of these changes is to offer users more flexibility and control over their CI/CD pipelines, ensuring each task within the Dependency Track plugin is purpose-driven and efficiently executed.