### PR TITLE
fix: resolve gradle task dependencies for plugin properties

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,6 +62,9 @@ tasks {
     withType(ProcessResources::class.java) {
         dependsOn(propertiesTask)
     }
+    withType(Jar::class.java) {
+        dependsOn(propertiesTask)
+    }
 }
 
 tasks.named("publishPlugins") {


### PR DESCRIPTION
- Add dependency on writePluginProperties task for all Jar tasks
- Resolve implicit dependency error in publish process

https://github.com/Liftric/dependency-track-companion-plugin/actions/runs/10389981070/job/28769347701