### PR TITLE
Implement new Async Token Endpoint for SBOM/Vex/Analyze Task

### DIFF
--- a/src/main/kotlin/com/liftric/dtcp/model/DependencyTrack.kt
+++ b/src/main/kotlin/com/liftric/dtcp/model/DependencyTrack.kt
@@ -87,7 +87,7 @@ data class Analysis(
 )
 
 @Serializable
-data class UploadSBOMResponse(val token: String)
+data class TaskTokenResponse(val token: String)
 
 @Serializable
 data class EventTokenResponse(val processing: Boolean)

--- a/src/main/kotlin/com/liftric/dtcp/model/DependencyTrack.kt
+++ b/src/main/kotlin/com/liftric/dtcp/model/DependencyTrack.kt
@@ -90,4 +90,4 @@ data class Analysis(
 data class UploadSBOMResponse(val token: String)
 
 @Serializable
-data class SBOMProcessingResponse(val processing: Boolean)
+data class EventTokenResponse(val processing: Boolean)

--- a/src/main/kotlin/com/liftric/dtcp/service/DependencyTrack.kt
+++ b/src/main/kotlin/com/liftric/dtcp/service/DependencyTrack.kt
@@ -20,7 +20,7 @@ class DependencyTrack(apiKey: String, private val baseUrl: String) {
         client.getRequest(url).body()
     }
 
-    fun analyzeProjectFindings(projectUUID: String): UploadSBOMResponse = runBlocking {
+    fun analyzeProjectFindings(projectUUID: String): TaskTokenResponse = runBlocking {
         val url = "$baseUrl/api/v1/finding/project/$projectUUID/analyze"
         client.postRequest(url).body()
     }
@@ -40,7 +40,7 @@ class DependencyTrack(apiKey: String, private val baseUrl: String) {
         projectUUID: String?,
         projectName: String?,
         projectVersion: String?,
-    ) = runBlocking {
+    ): TaskTokenResponse = runBlocking {
         val url = "$baseUrl/api/v1/vex"
         client.uploadFileWithFormData(url, file, "vex") {
             projectUUID?.let {
@@ -52,7 +52,7 @@ class DependencyTrack(apiKey: String, private val baseUrl: String) {
             projectVersion?.let {
                 append("projectVersion", it)
             }
-        }
+        }.body()
     }
 
     fun uploadSbom(
@@ -64,7 +64,7 @@ class DependencyTrack(apiKey: String, private val baseUrl: String) {
         parentUUID: String?,
         parentName: String?,
         parentVersion: String?,
-    ): UploadSBOMResponse = runBlocking {
+    ): TaskTokenResponse = runBlocking {
         val url = "$baseUrl/api/v1/bom"
         val res = client.uploadFileWithFormData(url, file, "bom") {
             append("autoCreate", autoCreate)

--- a/src/main/kotlin/com/liftric/dtcp/service/DependencyTrack.kt
+++ b/src/main/kotlin/com/liftric/dtcp/service/DependencyTrack.kt
@@ -90,16 +90,16 @@ class DependencyTrack(apiKey: String, private val baseUrl: String) {
         res.body()
     }
 
-    fun waitForSbomAnalysis(token: String) = runBlocking {
-        val url = "$baseUrl/api/v1/bom/token/$token"
-        var response: SBOMProcessingResponse
+    fun waitForTokenCompletion(token: String) = runBlocking {
+        val url = "$baseUrl/api/v1/event/token/$token"
+        var response: EventTokenResponse
 
         do {
-            println("Waiting for SBOM Analysis Processing...")
+            println("Waiting for task completion...")
             delay(2000)
             response = client.getRequest(url).body()
         } while (response.processing)
-        println("Analysis is complete.")
+        println("Task is complete.")
     }
 
     fun createProject(project: CreateProject) = runBlocking {

--- a/src/main/kotlin/com/liftric/dtcp/tasks/AnalyzeProjectTask.kt
+++ b/src/main/kotlin/com/liftric/dtcp/tasks/AnalyzeProjectTask.kt
@@ -48,6 +48,7 @@ abstract class AnalyzeProjectTask : DefaultTask() {
             else -> throw GradleException("Either projectUUID or projectName and projectVersion must be set")
         }
 
-        dt.analyzeProjectFindings(uuid)
+        val response = dt.analyzeProjectFindings(uuid)
+        dt.waitForTokenCompletion(response.token)
     }
 }

--- a/src/main/kotlin/com/liftric/dtcp/tasks/UploadSBOMTask.kt
+++ b/src/main/kotlin/com/liftric/dtcp/tasks/UploadSBOMTask.kt
@@ -76,6 +76,6 @@ abstract class UploadSBOMTask : DefaultTask() {
             parentName = parentNameValue,
             parentVersion = parentVersionValue,
         )
-        dt.waitForSbomAnalysis(response.token)
+        dt.waitForTokenCompletion(response.token)
     }
 }

--- a/src/main/kotlin/com/liftric/dtcp/tasks/UploadVexTask.kt
+++ b/src/main/kotlin/com/liftric/dtcp/tasks/UploadVexTask.kt
@@ -45,12 +45,13 @@ abstract class UploadVexTask : DefaultTask() {
         }
 
         val dt = DependencyTrack(apiKeyValue, urlValue)
-        dt.uploadVex(
+        val response = dt.uploadVex(
             file = outputFileValue,
             projectUUID = projectUUIDValue,
             projectName = projectNameValue,
             projectVersion = projectVersionValue,
         )
+        dt.waitForTokenCompletion(response.token)
         logger.info("Uploaded VEX file to Dependency-Track")
     }
 }


### PR DESCRIPTION
Dependency-Track v4.11 deprecated the old SBOM token endpoint in favor of a new general /event/token endpoint.

This PR:

- Replaces the deprecated SBOM token endpoint with the new general one
- Adds waiting logic to VEX upload and analysis tasks
- Updates existing SBOM upload to use the new endpoint

[Breaking Change]
- Requires Dependency-Track API v4.11+ (new event token endpoint)