### PR TITLE
Support for ignoring errors during upload

### DIFF
--- a/src/main/kotlin/com/liftric/dtcp/DepTrackCompanionPlugin.kt
+++ b/src/main/kotlin/com/liftric/dtcp/DepTrackCompanionPlugin.kt
@@ -54,6 +54,7 @@ class DepTrackCompanionPlugin : Plugin<Project> {
             task.parentUUID.set(extension.parentUUID)
             task.parentName.set(extension.parentName)
             task.parentVersion.set(extension.parentVersion)
+            task.ignoreErrors.set(extension.ignoreErrors)
             task.dependsOn(generateSbom)
         }
 

--- a/src/main/kotlin/com/liftric/dtcp/extensions/DepTrackCompanionExtension.kt
+++ b/src/main/kotlin/com/liftric/dtcp/extensions/DepTrackCompanionExtension.kt
@@ -23,6 +23,7 @@ abstract class DepTrackCompanionExtension(val project: Project) {
     abstract val parentName: Property<String>
     abstract val parentVersion: Property<String>
     abstract val ignoreProjectAlreadyExists: Property<Boolean>
+    abstract val ignoreErrors: Property<Boolean>
 
     abstract val riskScoreData: Property<RiskScoreBuilder>
 

--- a/src/main/kotlin/com/liftric/dtcp/tasks/UploadSBOMTask.kt
+++ b/src/main/kotlin/com/liftric/dtcp/tasks/UploadSBOMTask.kt
@@ -1,6 +1,7 @@
 package com.liftric.dtcp.tasks
 
 import com.liftric.dtcp.service.DependencyTrack
+import io.ktor.client.plugins.ResponseException
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.file.RegularFileProperty
@@ -48,6 +49,10 @@ abstract class UploadSBOMTask : DefaultTask() {
     @get:Optional
     abstract val parentVersion: Property<String>
 
+    @get:Input
+    @get:Optional
+    abstract val ignoreErrors: Property<Boolean>
+
     @TaskAction
     fun uploadSBOMTask() {
         val inputFileValue = inputFile.get().asFile
@@ -60,22 +65,32 @@ abstract class UploadSBOMTask : DefaultTask() {
         val parentNameValue = parentName.orNull
         val parentVersionValue = parentVersion.orNull
         val parentUUIDValue = parentUUID.orNull
+        val ignoreErrors = ignoreErrors.getOrElse(false)
 
         if (projectUUIDValue == null && (projectNameValue == null && projectVersionValue == null)) {
             throw GradleException("Either projectUUID or projectName and projectVersion must be set")
         }
 
         val dt = DependencyTrack(apiKeyValue, urlValue)
-        val response = dt.uploadSbom(
-            file = inputFileValue,
-            autoCreate = autoCreateValue,
-            projectUUID = projectUUIDValue,
-            projectName = projectNameValue,
-            projectVersion = projectVersionValue,
-            parentUUID = parentUUIDValue,
-            parentName = parentNameValue,
-            parentVersion = parentVersionValue,
-        )
-        dt.waitForTokenCompletion(response.token)
+        try {
+            val response = dt.uploadSbom(
+                file = inputFileValue,
+                autoCreate = autoCreateValue,
+                projectUUID = projectUUIDValue,
+                projectName = projectNameValue,
+                projectVersion = projectVersionValue,
+                parentUUID = parentUUIDValue,
+                parentName = parentNameValue,
+                parentVersion = parentVersionValue,
+            )
+            dt.waitForTokenCompletion(response.token)
+        }
+        catch (e: ResponseException) {
+            if (ignoreErrors) {
+                logger.warn("Error uploading SBOM: ${e.message}")
+            } else {
+                throw e
+            }
+        }
     }
 }


### PR DESCRIPTION
Added an extra flag in the extension for ignoring errors during upload. We've had cases where the dependencytrack server was temporarily down, and this caused our build pipelines to fail. This flag prevents that.