### PR TITLE
fix: use correct project parameter for VEX upload endpoint

### DIFF
--- a/src/main/kotlin/com/liftric/dtcp/service/DependencyTrack.kt
+++ b/src/main/kotlin/com/liftric/dtcp/service/DependencyTrack.kt
@@ -44,7 +44,7 @@ class DependencyTrack(apiKey: String, private val baseUrl: String, private val d
         val url = "$baseUrl/api/v1/vex"
         client.uploadFileWithFormData(url, file, "vex") {
             projectUUID?.let {
-                append("projectUUID", it)
+                append("project", it)
             }
             projectName?.let {
                 append("projectName", it)


### PR DESCRIPTION
The VEX upload endpoint was using an incorrect parameter name `projectUUID` instead of the expected `project` parameter.

https://yoursky.blue/documentation/rest-api#tag/vex/operation/uploadVex